### PR TITLE
Apply fixes to solve Sphinx warnings

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -87,7 +87,7 @@ Property                           Type     Units             Constraints     Re
 
 .. [#] ``fuel`` choices are "electricity", "natural gas", "fuel oil", "propane", "coal", "wood", and "wood pellets".
 
-.. _automated_measures:
+.. _schema_automated_measures:
 
 Automated Measures
 ******************
@@ -193,9 +193,9 @@ The attic is entered in ``...building.enclosure.attics``. Currently, this array 
 Property                           Type     Units             Constraints     Required  Default             Notes
 =================================  =======  ================  ==============  ========  ==================  ==============================================       
 ``id``                             id                         Must be unique  yes       Attic1  
-``area``                           float   ft2                >0              no        PSC    
-``isVented``                       boolean                                    no        yes    
-``floorAssemblyEffectiveRValue``   float   F-ft2-hr/Btu       >0              no        BSA   
+``area``                           float    ft2               >0              no        PSC
+``isVented``                       boolean                                    no        yes
+``floorAssemblyEffectiveRValue``   float    F-ft2-hr/Btu      >0              no        BSA
 =================================  =======  ================  ==============  ========  ==================  ============================================== 
 
 Roofs
@@ -405,7 +405,7 @@ Property                           Type     Units                       Constrai
 .. [#] Required when ``backupSystem.systemType`` is "separate".
 
 HVAC Air Distribution Systems
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Each separate air distribution system can be entered in ``...building.systems.hvac.hvacDistributionSystems.airDistributionSystems``.
 

--- a/docs/source/automated_measures.rst
+++ b/docs/source/automated_measures.rst
@@ -82,7 +82,7 @@ Operations on the existing cooling systems are entered in ``automatedMeasures.ex
   .. [#] The ``adjust`` object is required if ``action`` is set to ``adjust``.
   .. [#] Defaults to ``[]`` if not provided.
 
-  .. note::
+.. note::
 
   If ``action`` = "remove" and the existing cooling system is a heat pump, then the existing heating system will also be removed. This is based on the assumption that the ``newHeatPump`` will serve both loads.
 
@@ -224,6 +224,7 @@ Characteristics of a new water heating system can be entered in ``automatedMeasu
 
   .. [#] systemType choices are "storage water heater", "instantaneous water heater", and "heat pump water heater"
   .. [#] efficiencyClass choices are "standard" or "premium"
+  .. [#]
 
 
 Assumptions for ``efficiencyClass``:

--- a/docs/source/automated_measures.rst
+++ b/docs/source/automated_measures.rst
@@ -152,7 +152,7 @@ Operations on the existing water heating system can be entered in ``automatedMea
 
      **"keep"** maintains existing water heating system as is, including load percentage. Using this action indicates that there are no changes to the water heating system at all. This action will override anything in ``adjust`` object.
 
-     **"remove"** indicates the existing water heating system is completely removed. New system(s) must cover 100% of load or specify ``loadGapPercentage``. This action will override anything in ``adjust`` object.
+     **"remove"** indicates the existing water heating system is completely removed. This action will override anything in ``adjust`` object.
 
   .. [#] The ``adjust`` object is required if ``action`` is set to ``adjust``.
   .. [#] Defaults to ``[]`` if not provided.
@@ -222,9 +222,9 @@ Characteristics of a new water heating system can be entered in ``automatedMeasu
   ``costs``              Array of :ref:`cost`               No        ``[]``   Implied costs of measure
   =====================  ====================  ===========  ========  =======  ===================================
 
-  .. [#] systemType choices are "storage water heater", "instantaneous water heater", and "heat pump water heater"
-  .. [#] efficiencyClass choices are "standard" or "premium"
-  .. [#]
+  .. [#] ``systemType`` choices are "storage water heater", "instantaneous water heater", and "heat pump water heater"
+  .. [#] ``efficiencyClass`` choices are "standard" or "premium"
+  .. [#] The sum of ``dhwLoadPercentage`` across all water heating systems must be less than 1.
 
 
 Assumptions for ``efficiencyClass``:


### PR DESCRIPTION
Problems reported by Sphinx:

```/home/docs/checkouts/readthedocs.org/user_builds/radiant-labs-modeling-api-documentation/checkouts/latest/docs/source/api.rst:196: ERROR: Malformed table.
Text in column margin in table line 5.

=================================  =======  ================  ==============  ========  ==================  ==============================================
Property                           Type     Units             Constraints     Required  Default             Notes
=================================  =======  ================  ==============  ========  ==================  ==============================================
``id``                             id                         Must be unique  yes       Attic1
``area``                           float   ft2                >0              no        PSC
``isVented``                       boolean                                    no        yes
``floorAssemblyEffectiveRValue``   float   F-ft2-hr/Btu       >0              no        BSA
=================================  =======  ================  ==============  ========  ==================  ==============================================
/home/docs/checkouts/readthedocs.org/user_builds/radiant-labs-modeling-api-documentation/checkouts/latest/docs/source/api.rst:408: WARNING: Title underline too short.

HVAC Air Distribution Systems
~~~~~~~~~~~~~~~~~~~~~~~~~
/home/docs/checkouts/readthedocs.org/user_builds/radiant-labs-modeling-api-documentation/checkouts/latest/docs/source/api.rst:408: WARNING: Title underline too short.

HVAC Air Distribution Systems
~~~~~~~~~~~~~~~~~~~~~~~~~
/home/docs/checkouts/readthedocs.org/user_builds/radiant-labs-modeling-api-documentation/checkouts/latest/docs/source/automated_measures.rst:85: ERROR: Content block expected for the "note" directive; none found.
/home/docs/checkouts/readthedocs.org/user_builds/radiant-labs-modeling-api-documentation/checkouts/latest/docs/source/automated_measures.rst:335: ERROR: Too many autonumbered footnote references: only 22 corresponding footnotes available.
/home/docs/checkouts/readthedocs.org/user_builds/radiant-labs-modeling-api-documentation/checkouts/latest/docs/source/automated_measures.rst:4: WARNING: duplicate label automated_measures, other instance in /home/docs/checkouts/readthedocs.org/user_builds/radiant-labs-modeling-api-documentation/checkouts/latest/docs/source/api.rst```